### PR TITLE
Bump merge-deep from 3.0.1 to 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,14 +2149,13 @@
             "dev": true
         },
         "merge-deep": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.1.tgz",
-            "integrity": "sha512-N+5I5QfuiwzJOUecCejlshp8RrBPJAHUXL6pWeXjF7u0fOpKFUAD1YRJ0dEJEzQcuOes4rHQTvGm0B8cgvA1OA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+            "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
             "requires": {
                 "arr-union": "^3.1.0",
                 "clone-deep": "^0.2.4",
-                "kind-of": "^3.0.2",
-                "lazy-cache": "^1.0.3"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "arr-union": {


### PR DESCRIPTION
Finding keys points of Bumps [merge-deep](https://github.com/jonschlinkert/merge-deep) from 3.0.1 to 3.0.3.
- [Release notes](https://github.com/jonschlinkert/merge-deep/releases)
- [Commits](https://github.com/jonschlinkert/merge-deep/compare/3.0.1...3.0.3)

---
updated-dependencies:
- dependency-name: merge-deep
  dependency-type: indirect
...

why merging is required and explains any required changes 